### PR TITLE
Medbee: Fix AppStore Submission when used via Carthage

### DIFF
--- a/DeepLinkKit/Info.plist
+++ b/DeepLinkKit/Info.plist
@@ -18,6 +18,8 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>MinimumOSVersion</key>
+	<string>8.0</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
Embed Framework via Cartage results in following AppStore validation error:

![error](https://user-images.githubusercontent.com/18739004/76755870-ef847200-6784-11ea-8ff3-263294d6b3b5.png)

Using `carthage update --cache-builds --platform iOS` builds the framework with a default value for MinimumOSVersion of 7.0.

# Tasks
- [x] Increase MinimumOSVersion to 8.0